### PR TITLE
Release python version downgrade

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
         "Programming Language :: Python :: 3",
         "Operating System :: OS Independent",
     ],
-    python_requires=">= 3.9",
+    python_requires=">= 3.8",
     package_data={"wincpy": gather_package_data_paths()},
     entry_points={"console_scripts": ["wincpy=wincpy.__main__:console_entry"]},
     install_requires=["rich>=10.9.0"],

--- a/wincpy/__init__.py
+++ b/wincpy/__init__.py
@@ -1,2 +1,2 @@
 # Leave this empty other than the version
-__version__ = "1.1.1"
+__version__ = "1.1.2"

--- a/wincpy/__init__.py
+++ b/wincpy/__init__.py
@@ -1,2 +1,2 @@
 # Leave this empty other than the version
-__version__ = "1.1.0"
+__version__ = "1.1.1"


### PR DESCRIPTION
Is it ok to release the python version downgrade from a couple of weeks ago? If not, it's not a big issue. Anything else need changing? Perhaps Wincpy version number?